### PR TITLE
0.1.1 BigQuery Release 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/<PYPI_PACKAGE_NAME>
+      url: https://pypi.org/p/local-data-platform
     permissions:
       id-token: write
     steps:
@@ -28,6 +28,6 @@ jobs:
           python setup.py sdist bdist_wheel  # Could also be python -m build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        - name: pypi-publish
-                uses: pypa/gh-action-pypi-publish@v1.10.3
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.11.0
             

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Upload Python Package to PyPI when a Release is Created
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<PYPI_PACKAGE_NAME>
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel  # Could also be python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        - name: pypi-publish
+                uses: pypa/gh-action-pypi-publish@v1.10.3
+            


### PR DESCRIPTION
Create publish.yml for PYPI package release 

To automate the release of your Python package to PyPI through GitHub, you can use GitHub Actions1
. Here’s a step-by-step guide to set it up:

Create a PyPI API Token:

Go to your PyPI account settings and generate an API token2
.

Copy the token for later use2
.

Add the API Token to GitHub Secrets:

Go to your GitHub repository settings2
.

Navigate to Secrets and add a new repository secret named PYPI_API_TOKEN2
.

Paste your PyPI API token into the value field2
.

Create a GitHub Workflow File:

In your repository, create a new file at .github/workflows/release_to_pypi.yml2
.

Add the following content to the file: